### PR TITLE
Fix footer component imports

### DIFF
--- a/components/global/Footer/FooterLayout.tsx
+++ b/components/global/Footer/FooterLayout.tsx
@@ -1,6 +1,6 @@
 import type { PortableTextBlock } from '@portabletext/types'
 
-import { CustomPortableText } from '@/components//shared/CustomPortableText'
+import { CustomPortableText } from '@/components/shared/CustomPortableText'
 import type { SettingsPayload } from '@/types'
 
 interface FooterProps {

--- a/components/global/Footer/FooterPreview.tsx
+++ b/components/global/Footer/FooterPreview.tsx
@@ -8,7 +8,7 @@ type Props = {
   initial: Parameters<typeof useSettings>[0]
 }
 
-export default function NavbarPreview(props: Props) {
+export default function FooterPreview(props: Props) {
   const { data } = useSettings(props.initial)
 
   return <FooterLayout data={data!} />


### PR DESCRIPTION
## Summary
- fix import path for CustomPortableText in `FooterLayout`
- rename default export in `FooterPreview`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a9a96490832b804130b416e66e33