### PR TITLE
Add maintenance mode controlled via Sanity

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -10,6 +10,7 @@ import { Footer } from '@/components/global/Footer'
 import { Navbar } from '@/components/global/Navbar'
 import { urlForOpenGraphImage } from '@/sanity/lib/utils'
 import { loadHomePage, loadSettings } from '@/sanity/loader/loadQuery'
+import { isLoggedIn } from '@/sanity/lib/isLoggedIn'
 
 const LiveVisualEditing = dynamic(
   () => import('@/sanity/loader/LiveVisualEditing'),
@@ -47,6 +48,19 @@ export default async function IndexRoute({
 }: {
   children: React.ReactNode
 }) {
+  const { data: settings } = await loadSettings()
+
+  if (settings?.maintenanceMode) {
+    const loggedIn = await isLoggedIn()
+    if (!loggedIn) {
+      return (
+        <div className="flex min-h-screen items-center justify-center text-center">
+          Temporarily Undergoing Maintenance
+        </div>
+      )
+    }
+  }
+
   return (
     <>
       <div className="flex min-h-screen flex-col bg-white text-black">

--- a/sanity/lib/isLoggedIn.ts
+++ b/sanity/lib/isLoggedIn.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+
+import { cookies } from 'next/headers'
+
+import { client } from './client'
+
+export async function isLoggedIn(): Promise<boolean> {
+  const cookieValue =
+    cookies().get('sanitySession')?.value || cookies().get('__session')?.value
+
+  if (!cookieValue) {
+    return false
+  }
+
+  const authClient = client.withConfig({ token: cookieValue })
+  try {
+    const user = await authClient.users.getById('me')
+    return !!user
+  } catch {
+    return false
+  }
+}

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -40,6 +40,7 @@ export const settingsQuery = groq`
       "slug": slug.current,
       title
     },
+    maintenanceMode,
     ogImage,
   }
 `

--- a/sanity/schemas/singletons/settings.ts
+++ b/sanity/schemas/singletons/settings.ts
@@ -67,6 +67,13 @@ export default defineType({
         hotspot: true,
       },
     }),
+    defineField({
+      name: 'maintenanceMode',
+      title: 'Maintenance Mode',
+      type: 'boolean',
+      description:
+        'When enabled, only authenticated Sanity users can view the site.',
+    }),
   ],
   preview: {
     prepare() {

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,5 +44,6 @@ export interface PagePayload {
 export interface SettingsPayload {
   footer?: PortableTextBlock[]
   menuItems?: MenuItem[]
+  maintenanceMode?: boolean
   ogImage?: Image
 }


### PR DESCRIPTION
## Summary
- add `maintenanceMode` field to Sanity settings schema
- expose maintenanceMode in queries and Typescript types
- add server util to check if the current request is from a logged in Sanity user
- gate site rendering in `(root)/layout` when maintenance mode is enabled

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e856da5fc832bb769e143995d5056